### PR TITLE
Fix indentation in .cabal file

### DIFF
--- a/petsc-hs.cabal
+++ b/petsc-hs.cabal
@@ -21,11 +21,11 @@ library
   -- other-modules:       
   other-extensions:    ConstraintKinds, ForeignFunctionInterface, QuasiQuotes, TemplateHaskell, GeneralizedNewtypeDeriving, StandaloneDeriving, DeriveDataTypeable, DataKinds, MultiParamTypeClasses, BangPatterns, FunctionalDependencies, FlexibleInstances, TypeFamilies, FlexibleContexts, RankNTypes, CPP
   build-depends:       base >=4.7 && <4.8, 
-  		       template-haskell >=2.9 && <2.10, 
-		       containers >=0.5 && <0.6, 
-		       QuickCheck >=2.7 && <2.8, 
-		       bytestring >=0.10 && <0.11, 
-		       transformers >=0.3 && <0.4
+                       template-haskell >=2.9 && <2.10, 
+                       containers >=0.5 && <0.6, 
+                       QuickCheck >=2.7 && <2.8, 
+                       bytestring >=0.10 && <0.11, 
+                       transformers >=0.3 && <0.4
   hs-source-dirs:      src
   build-tools:         chs
   default-language:    Haskell2010


### PR DESCRIPTION
Cabal files may not contain tabs for indentation, see [`parsePackageDescription`](https://github.com/haskell/cabal/blob/49dba823de44584babc4d5bfcdd7673582b08436/Cabal/Distribution/PackageDescription/Parse.hs#L684-L707).

This PR basically replaces the tabs by 8 spaces. (@ocramz, make sure that you don't mix tabs and spaces in the other files)
