### PR TITLE
Use Travis APT addons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,16 @@ env:
  # - GHCVER=7.6.3  CABALVER=1.18 COVOPT=--enable-library-coverage
  #- GHCVER=head   CABALVER=head COVOPT=--enable-coverage
 
+# Install GFortran via apt-get.
+# See http://docs.travis-ci.com/user/apt/ for more information
+addons:
+  apt:
+    packages:
+    - gfortran
+
 before_install:
  # - ./download-petsc.sh
  # - ./install-petsc.sh
-
- - sudo apt-get install gfortran 
- 
  - mkdir petsc
  - cd petsc
  - wget http://ftp.mcs.anl.gov/pub/petsc/release-snapshots/petsc-lite-3.6.2.tar.gz


### PR DESCRIPTION
Instead of using `sudo`, use Travis' APT addons to install additional packages.

It's somewhat hidden in the [dependency documentation](http://docs.travis-ci.com/user/installing-dependencies/#Installing-Ubuntu-packages). gfortran is on [the whitelist](https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise), so it _should_ work.
